### PR TITLE
Support esr string in display version

### DIFF
--- a/treescript/test/test_versionmanip.py
+++ b/treescript/test/test_versionmanip.py
@@ -21,8 +21,7 @@ def context(tmpdir):
 
 
 @pytest.fixture(scope='function',
-                # XXX add 52.3.0esr to this set when we support esr here
-                params=('52.5.0', '52.0b3', '# foobar\n52.1a3'))
+                params=('52.5.0', '52.0b3', '# foobar\n52.1a3', '60.1.3esr'))
 def repo_context(tmpdir, context, request):
     context.repo = os.path.join(tmpdir, 'repo')
     context.xtest_version = request.param
@@ -43,7 +42,7 @@ def test_get_version(repo_context):
     assert ver == repo_context.xtest_version
 
 
-@pytest.mark.parametrize('new_version', ('87.0', '87.1b3', '123.2esr'))
+@pytest.mark.parametrize('new_version', ('87.0', '87.1b3'))
 def test_replace_ver_in_file(repo_context, new_version):
     filepath = os.path.join(repo_context.repo, 'config', 'milestone.txt')
     old_ver = repo_context.xtest_version
@@ -51,7 +50,7 @@ def test_replace_ver_in_file(repo_context, new_version):
     assert new_version == vmanip._get_version(filepath)
 
 
-@pytest.mark.parametrize('new_version', ('87.0', '87.1b3', '123.2esr'))
+@pytest.mark.parametrize('new_version', ('87.0', '87.1b3'))
 def test_replace_ver_in_file_invalid_old_ver(repo_context, new_version):
     filepath = os.path.join(repo_context.repo, 'config', 'milestone.txt')
     old_ver = '45.0'
@@ -63,7 +62,6 @@ def test_replace_ver_in_file_invalid_old_ver(repo_context, new_version):
 @pytest.mark.parametrize('new_version', (
     '87.0',
     '87.1b3',
-    pytest.param('123.2esr', marks=pytest.mark.xfail)  # XXX 'esr' fails StrictVersion
 ))
 async def test_bump_version(mocker, repo_context, new_version):
     called_args = []
@@ -71,13 +69,17 @@ async def test_bump_version(mocker, repo_context, new_version):
     async def run_command(context, *arguments, local_repo=None):
         called_args.append([tuple([context]) + arguments, {'local_repo': local_repo}])
 
+    test_version = new_version
+    if repo_context.xtest_version.endswith('esr'):
+        test_version = new_version + 'esr'
+
     relative_files = [os.path.join('config', 'milestone.txt')]
     bump_info = {'files': relative_files, 'next_version': new_version}
     mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
     mocked_bump_info.return_value = bump_info
     mocker.patch.object(vmanip, 'run_hg_command', new=run_command)
     await vmanip.bump_version(repo_context)
-    assert new_version == vmanip._get_version(
+    assert test_version == vmanip._get_version(
         os.path.join(repo_context.repo, relative_files[0]))
     assert len(called_args) == 1
     assert 'local_repo' in called_args[0][1]
@@ -85,11 +87,7 @@ async def test_bump_version(mocker, repo_context, new_version):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('new_version', (
-    '87.0',
-    '87.1b3',
-    pytest.param('123.2esr', marks=pytest.mark.xfail)  # XXX 'esr' fails StrictVersion
-))
+@pytest.mark.parametrize('new_version', ('87.0', '87.1b3', '123.2esr'))
 async def test_bump_version_invalid_file(mocker, repo_context, new_version):
     called_args = []
 
@@ -109,11 +107,7 @@ async def test_bump_version_invalid_file(mocker, repo_context, new_version):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('new_version', (
-    '87.0',
-    '87.1b3',
-    pytest.param('123.2esr', marks=pytest.mark.xfail)  # XXX 'esr' fails StrictVersion
-))
+@pytest.mark.parametrize('new_version', ('87.0', '87.1b3', '123.2esr'))
 async def test_bump_version_missing_file(mocker, repo_context, new_version):
     called_args = []
 
@@ -134,11 +128,7 @@ async def test_bump_version_missing_file(mocker, repo_context, new_version):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('new_version', (
-    '27.0',
-    '26.1b3',
-    pytest.param('45.2esr', marks=pytest.mark.xfail)  # XXX 'esr' fails StrictVersion
-))
+@pytest.mark.parametrize('new_version', ('27.0', '26.1b3', '45.2esr'))
 async def test_bump_version_smaller_version(mocker, repo_context, new_version):
     called_args = []
 
@@ -154,6 +144,78 @@ async def test_bump_version_smaller_version(mocker, repo_context, new_version):
     assert repo_context.xtest_version == vmanip._get_version(
         os.path.join(repo_context.repo, relative_files[0]))
     assert len(called_args) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('new_version,expect_version', (
+    ('87.0', '87.0esr'),
+    ('87.1', '87.1esr'),
+    ('92.0.1', '92.0.1esr'),
+    ('76.9.10esr', '76.9.10esr')
+))
+async def test_bump_version_esr(mocker, repo_context, new_version, expect_version):
+    if not repo_context.xtest_version.endswith('esr'):
+        # XXX pytest.skip raised exceptions here for some reason.
+        return
+
+    called_args = []
+
+    async def run_command(context, *arguments, local_repo=None):
+        called_args.append([tuple([context]) + arguments, {'local_repo': local_repo}])
+
+    relative_files = [os.path.join('config', 'milestone.txt')]
+    bump_info = {'files': relative_files, 'next_version': new_version}
+    mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
+    mocked_bump_info.return_value = bump_info
+    mocker.patch.object(vmanip, 'run_hg_command', new=run_command)
+    await vmanip.bump_version(repo_context)
+    assert expect_version == vmanip._get_version(
+        os.path.join(repo_context.repo, relative_files[0]))
+    assert len(called_args) == 1
+    assert 'local_repo' in called_args[0][1]
+    assert is_slice_in_list(('commit', '-m'), called_args[0][0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('new_version,expect_esr_version', (
+    ('87.0', '87.0esr'),
+    ('87.1', '87.1esr'),
+    ('92.0.1', '92.0.1esr'),
+))
+async def test_bump_version_esr_dont_bump_non_esr(mocker, context, tmpdir,
+                                                  new_version, expect_esr_version):
+    version = '56.0.1'
+    context.repo = os.path.join(tmpdir, 'repo')
+    os.mkdir(context.repo)
+    os.mkdir(os.path.join(context.repo, 'config'))
+    os.makedirs(os.path.join(context.repo, 'browser', 'config'))
+    version_file = os.path.join(context.repo, 'config', 'milestone.txt')
+    with open(version_file, 'w') as f:
+        f.write(version)
+    display_version_file = os.path.join(context.repo, 'browser',
+                                        'config', 'version_display.txt')
+    with open(display_version_file, 'w') as f:
+        f.write(version + 'esr')
+
+    called_args = []
+
+    async def run_command(context, *arguments, local_repo=None):
+        called_args.append([tuple([context]) + arguments, {'local_repo': local_repo}])
+
+    relative_files = [
+        os.path.join('browser', 'config', 'version_display.txt'),
+        os.path.join('config', 'milestone.txt')
+    ]
+    bump_info = {'files': relative_files, 'next_version': new_version}
+    mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
+    mocked_bump_info.return_value = bump_info
+    mocker.patch.object(vmanip, 'run_hg_command', new=run_command)
+    await vmanip.bump_version(context)
+    assert expect_esr_version == vmanip._get_version(
+        os.path.join(context.repo, display_version_file))
+    assert new_version == vmanip._get_version(
+        os.path.join(context.repo, version_file))
+    assert len(called_args) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@rail as we discussed the other day, this should allow us to have '60.1.0esr' in display version, and product can then pass '60.1.1' as an app version and the bumps will "just work" for both milestone.txt and display_version.

This fixes issue #16 