### PR TITLE
Bug 1470232 Add push verification option

### DIFF
--- a/treescript/exceptions.py
+++ b/treescript/exceptions.py
@@ -29,3 +29,17 @@ class FailedSubprocess(ScriptWorkerTaskException):
         super(FailedSubprocess, self).__init__(
             msg, exit_code=STATUSES['internal-error']
         )
+
+
+class BumpVerificationError(ScriptWorkerTaskException):
+    """Something went wrong with a version bump."""
+
+    def __init__(self, msg):
+        """Initialize BumpVerificationError.
+
+        Args:
+            msg (str): the reason for throwing an exception.
+        """
+        super(BumpVerificationError, self).__init__(
+            msg, exit_code=STATUSES['internal-error']
+        )

--- a/treescript/test/test_utils.py
+++ b/treescript/test/test_utils.py
@@ -9,9 +9,9 @@ from treescript.exceptions import TaskVerificationError, FailedSubprocess
 
 assert tmpdir  # silence flake8
 
-TEST_ACTION_TAG = 'project:releng:treescript:action:tagging'
-TEST_ACTION_BUMP = 'project:releng:treescript:action:version_bump'
-TEST_ACTION_INVALID = 'project:releng:treescript:action:invalid'
+TEST_ACTION_TAG = 'tagging'
+TEST_ACTION_BUMP = 'version_bump'
+TEST_ACTION_INVALID = 'invalid'
 
 
 # mkdir {{{1
@@ -44,7 +44,7 @@ def test_mkdir_mutes_os_errors(mocker):
     'scopes', ([TEST_ACTION_TAG], [TEST_ACTION_BUMP], [TEST_ACTION_TAG, TEST_ACTION_BUMP])
 )
 def test_task_action_types_valid_scopes(scopes):
-    task = {"scopes": scopes}
+    task = {"scopes": ["project:releng:treescript:action:{}".format(s) for s in scopes]}
     assert tuple(scopes) == utils.task_action_types(task)
 
 

--- a/treescript/test/test_versionmanip.py
+++ b/treescript/test/test_versionmanip.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 from scriptworker.context import Context
-from treescript.exceptions import TaskVerificationError
+from treescript.exceptions import TaskVerificationError, BumpVerificationError
 from treescript.test import tmpdir, is_slice_in_list
 from treescript.script import get_default_config
 import treescript.versionmanip as vmanip
@@ -84,6 +84,30 @@ async def test_bump_version(mocker, repo_context, new_version):
     assert len(called_args) == 1
     assert 'local_repo' in called_args[0][1]
     assert is_slice_in_list(('commit', '-m'), called_args[0][0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('new_version', (
+    '87.0',
+    '87.1b3',
+))
+async def test_bump_version_write_failed(mocker, repo_context, new_version):
+    called_args = []
+
+    async def run_command(context, *arguments, local_repo=None):
+        called_args.append([tuple([context]) + arguments, {'local_repo': local_repo}])
+
+    def broken_replace_ver_in_file(file, curr_version, new_version):
+        pass
+
+    relative_files = [os.path.join('config', 'milestone.txt')]
+    bump_info = {'files': relative_files, 'next_version': new_version}
+    mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
+    mocked_bump_info.return_value = bump_info
+    mocker.patch.object(vmanip, 'run_hg_command', new=run_command)
+    mocker.patch.object(vmanip, 'replace_ver_in_file', new=broken_replace_ver_in_file)
+    with pytest.raises(BumpVerificationError):
+        await vmanip.bump_version(repo_context)
 
 
 @pytest.mark.asyncio
@@ -234,3 +258,61 @@ async def test_bump_version_same_version(mocker, repo_context):
     assert repo_context.xtest_version == vmanip._get_version(
         os.path.join(repo_context.repo, relative_files[0]))
     assert len(called_args) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('new_version', (
+    '87.0',
+    '87.1b3',
+    '87.0esr'
+))
+async def test_verify_bump(mocker, repo_context, new_version):
+
+    relative_files = [os.path.join('config', 'milestone.txt')]
+    bump_info = {'files': relative_files, 'next_version': new_version}
+    mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
+    mocked_bump_info.return_value = bump_info
+    mocked_get_version = mocker.patch.object(vmanip, '_get_version')
+    mocked_get_version.return_value = new_version
+    await vmanip.verify_bump(repo_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('new_version', (
+    '87.0',
+    '87.1b3',
+    '87.0esr'
+))
+async def test_verify_bump_version_mismatch(mocker, repo_context, new_version):
+
+    relative_files = [os.path.join('config', 'milestone.txt')]
+    bump_info = {'files': relative_files, 'next_version': new_version}
+    mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
+    mocked_bump_info.return_value = bump_info
+    # mocked_get_version = mocker.patch.object(vmanip, '_get_version')
+    # mocked_get_version.return_value = new_version
+    with pytest.raises(BumpVerificationError):
+        await vmanip.verify_bump(repo_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('new_version', ('87.0', '87.1b3', '123.2esr'))
+async def test_verify_bump_invalid_file(mocker, repo_context, new_version):
+    relative_files = [os.path.join('config', 'invalid_file.txt'), os.path.join('config', 'milestone.txt')]
+    bump_info = {'files': relative_files, 'next_version': new_version}
+    mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
+    mocked_bump_info.return_value = bump_info
+    with pytest.raises(TaskVerificationError):
+        await vmanip.verify_bump(repo_context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('new_version', ('87.0', '87.1b3', '123.2esr'))
+async def test_verify_bump_missing_file(mocker, repo_context, new_version):
+    # Test only creates config/milestone.txt
+    relative_files = [os.path.join('browser', 'config', 'version_display.txt'), os.path.join('config', 'milestone.txt')]
+    bump_info = {'files': relative_files, 'next_version': new_version}
+    mocked_bump_info = mocker.patch.object(vmanip, 'get_version_bump_info')
+    mocked_bump_info.return_value = bump_info
+    with pytest.raises(TaskVerificationError):
+        await vmanip.verify_bump(repo_context)

--- a/treescript/utils.py
+++ b/treescript/utils.py
@@ -8,7 +8,7 @@ from treescript.exceptions import TaskVerificationError, FailedSubprocess
 
 log = logging.getLogger(__name__)
 
-VALID_ACTIONS = ("tagging", "version_bump", "push")
+VALID_ACTIONS = ("tagging", "version_bump", "push", "verify_bump")
 
 
 # mkdir {{{1
@@ -40,15 +40,12 @@ def task_action_types(task):
         str: the cert type.
 
     """
-    valid_action_scopes = tuple(
-        "project:releng:treescript:action:{}".format(action) for action in VALID_ACTIONS
-    )
-    actions = tuple(s for s in task["scopes"] if
-                    s.startswith("project:releng:treescript:action:"))
+    prefix = 'project:releng:treescript:action:'
+    actions = tuple(s.replace(prefix, '') for s in task["scopes"] if s.startswith(prefix))
     log.info("Action requests: %s", actions)
     if len(actions) < 1:
         raise TaskVerificationError("Need at least one valid action specified in scopes")
-    invalid_actions = set(actions) - set(valid_action_scopes)
+    invalid_actions = set(actions) - set(VALID_ACTIONS)
     if len(invalid_actions) > 0:
         raise TaskVerificationError("Task specified invalid actions: {}".format(invalid_actions))
     return actions


### PR DESCRIPTION
Adding the verify_bump scope will now refresh hg and ensure that the new version is not only written, but exists remotely.