### PR TITLE
Bug 1470232 Improving version bump safety

### DIFF
--- a/treescript/exceptions.py
+++ b/treescript/exceptions.py
@@ -29,3 +29,17 @@ class FailedSubprocess(ScriptWorkerTaskException):
         super(FailedSubprocess, self).__init__(
             msg, exit_code=STATUSES['internal-error']
         )
+
+
+class ChangesetMismatchError(ScriptWorkerTaskException):
+    """An incorrect number of changesets would be pushed."""
+
+    def __init__(self, msg):
+        """Initialize ChangesetMismatchError.
+
+        Args:
+            msg (str): the reason for throwing an exception.
+        """
+        super(ChangesetMismatchError, self).__init__(
+            msg, exit_code=STATUSES['internal-error']
+        )

--- a/treescript/mercurial.py
+++ b/treescript/mercurial.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from treescript.utils import execute_subprocess
-from treescript.exceptions import FailedSubprocess
+from treescript.exceptions import FailedSubprocess, ChangesetMismatchError
 from treescript.task import get_source_repo, get_tag_info
 
 # https://www.mercurial-scm.org/repo/hg/file/tip/tests/run-tests.py#l1040
@@ -90,7 +90,7 @@ async def run_hg_command(context, *args, local_repo=None):
     env = build_hg_environment()
     if local_repo:
         command.extend(['-R', local_repo])
-    await execute_subprocess(command, env=env)
+    return await execute_subprocess(command, env=env)
 
 
 # log_mercurial_version {{{1
@@ -205,6 +205,23 @@ async def log_outgoing(context, directory):
     dest_repo = get_source_repo(context.task)
     log.info("outgoing changesets..")
     await run_hg_command(context, 'out', '-vp', '-r', '.', dest_repo, local_repo=local_repo)
+
+
+async def assert_outgoing(context, directory, expected_cset_count):
+    """Run `hg out` to ensure the expected number of changes exist.
+
+    Assuming that each action produces one changeset, we can
+    check to see if we'd push to the right location by comparing
+    the results of 'hg out' - if it's not equal to the number
+    of actions, we have unexpected changes to push.
+    """
+    local_repo = os.path.join(directory, 'src')
+    dest_repo = get_source_repo(context.task)
+    log.info("outgoing changesets..")
+    changesets = await run_hg_command(context, 'out', '-q', '-r', '.', dest_repo, local_repo=local_repo)
+    if len(changesets) != expected_cset_count:
+        raise ChangesetMismatchError(
+            'Expected {} changesets to push, found {}'.format(expected_cset_count, changesets))
 
 
 async def push(context):

--- a/treescript/script.py
+++ b/treescript/script.py
@@ -8,7 +8,7 @@ import scriptworker.client
 from scriptworker.exceptions import ScriptWorkerException
 from treescript.utils import task_action_types, is_dry_run
 from treescript.mercurial import log_mercurial_version, validate_robustcheckout_works, \
-    checkout_repo, do_tagging, log_outgoing, push
+    checkout_repo, do_tagging, log_outgoing, assert_outgoing, push
 from treescript.versionmanip import bump_version
 
 log = logging.getLogger(__name__)
@@ -29,6 +29,8 @@ async def do_actions(context, actions, directory):
         else:
             raise NotImplementedError("Unexpected action")
     await log_outgoing(context, directory)
+    # 'push' doesn't generate a changeset, the other actions do.
+    await assert_outgoing(context, directory, len(actions)-actions.count('push'))
     if is_dry_run(context.task):
         log.info("Not pushing changes, dry_run was forced")
     elif 'push' in actions:

--- a/treescript/test/test_script.py
+++ b/treescript/test/test_script.py
@@ -109,6 +109,7 @@ async def test_do_actions(mocker, context, push_scope, dry_run, push_expect_call
     mocker.patch.object(script, 'bump_version', new=mocked_bump)
     mocker.patch.object(script, 'push', new=mocked_push)
     mocker.patch.object(script, 'log_outgoing', new=noop_async)
+    mocker.patch.object(script, 'assert_outgoing', new=noop_async)
     mocker.patch.object(script, 'is_dry_run').return_value = dry_run
     await script.do_actions(context, actions, directory='/some/folder/here')
     assert called_tag[0]

--- a/treescript/test/test_utils.py
+++ b/treescript/test/test_utils.py
@@ -85,9 +85,9 @@ def test_is_dry_run_true():
     assert True is utils.is_dry_run(task)
 
 
-# log_output {{{1
+# process_output {{{1
 @pytest.mark.asyncio
-async def test_log_output(tmpdir, mocker):
+async def test_process_output(tmpdir, mocker):
     logged = []
     with open(__file__, 'r') as fh:
         contents = fh.read()
@@ -113,7 +113,7 @@ async def test_log_output(tmpdir, mocker):
     mockfh = mock.MagicMock()
     aiter = AsyncIterator()
     mockfh.readline = aiter.__anext__
-    await utils.log_output(mockfh)
+    await utils.process_output(mockfh)
     assert contents.rstrip() == '\n'.join(logged)
 
 

--- a/treescript/utils.py
+++ b/treescript/utils.py
@@ -78,20 +78,24 @@ def is_dry_run(task):
     return dry_run
 
 
-# log_output {{{1
-async def log_output(fh):
+# process_output {{{1
+async def process_output(fh):
     """Log the output from an async generator.
 
     Args:
         fh (async generator): the async generator to log output from
 
     """
+    output = []
     while True:
         line = await fh.readline()
         if line:
-            log.info(line.decode("utf-8").rstrip())
+            line = line.decode("utf-8").rstrip()
+            log.info(line)
+            output.append(line)
         else:
             break
+    return output
 
 
 # execute_subprocess {{{1
@@ -114,9 +118,10 @@ async def execute_subprocess(command, **kwargs):
         *command, stdout=PIPE, stderr=STDOUT, **kwargs
     )
     log.info("COMMAND OUTPUT: ")
-    await log_output(subprocess.stdout)
+    output = await process_output(subprocess.stdout)
     exitcode = await subprocess.wait()
     log.info("exitcode {}".format(exitcode))
 
     if exitcode != 0:
         raise FailedSubprocess('Command `{}` failed'.format(' '.join(command)))
+    return output


### PR DESCRIPTION
Using the assumption that each non-push action generates one changeset, we can compare the results of `hg out` to the number of actions, and if they're not the same then we've either missed an action, or are not pushing to the correct repository.