### PR TITLE
Removes "schema_file" from config file

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -7,7 +7,6 @@
     "hg": "hg",
     "hg_share_base_dir": "/tmp/hg_share_base",
     "upstream_repo": "https://hg.mozilla.org/mozilla-unified",
-    "schema_file": "treescript/data/treescript_task_schema.json",
 
     "hg_ssh_user": "some_user",
     "hg_ssh_keyfile": "some_file.rsa"


### PR DESCRIPTION
`treescript` already has a great `schema_file` default based off of `__file__`